### PR TITLE
Upgrade GitHub workflows to Node 24 and disable package manager cache

### DIFF
--- a/.github/workflows/raw-capture-automerge.yml
+++ b/.github/workflows/raw-capture-automerge.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 24
+          package-manager-cache: false
 
       - name: Enable pnpm
         run: corepack enable

--- a/.github/workflows/raw-capture-automerge.yml
+++ b/.github/workflows/raw-capture-automerge.yml
@@ -13,6 +13,9 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  NODE_VERSION: 24
+
 concurrency:
   group: raw-capture-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -29,19 +32,20 @@ jobs:
 
     steps:
       - name: Checkout pull request head
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Set up Node
-        uses: actions/setup-node@v5
-        with:
-          node-version: 24
-          package-manager-cache: false
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
 
-      - name: Enable pnpm
-        run: corepack enable
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/raw-inbox-import.yml
+++ b/.github/workflows/raw-inbox-import.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 24
+          package-manager-cache: false
 
       - name: Create capture PR
         if: steps.should-run.outputs.run == 'true'

--- a/.github/workflows/raw-inbox-import.yml
+++ b/.github/workflows/raw-inbox-import.yml
@@ -16,6 +16,9 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  NODE_VERSION: 24
+
 concurrency:
   group: raw-inbox-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: false
@@ -42,15 +45,15 @@ jobs:
 
       - name: Checkout
         if: steps.should-run.outputs.run == 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node
         if: steps.should-run.outputs.run == 'true'
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           package-manager-cache: false
 
       - name: Create capture PR


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for `raw-capture-automerge` and `raw-inbox-import` to use newer action versions, standardizes Node.js version management, and improves dependency handling with pnpm. These changes will help keep CI up to date and more maintainable.

**Workflow dependency and environment improvements:**

* Added a global `NODE_VERSION` environment variable set to `24` in both `.github/workflows/raw-capture-automerge.yml` and `.github/workflows/raw-inbox-import.yml` to standardize Node.js version management. [[1]](diffhunk://#diff-d4dc7b4e773430bc8af8329183e7fad305888baf3ca2c7bc5fa4091928eb5899R16-R18) [[2]](diffhunk://#diff-5b85b19552657ec533ea8b978312f05fbac1d801a5c1b774dfcbe0aaa974422dR19-R21)
* Updated `actions/checkout` and `actions/setup-node` to version 6 in both workflows for improved reliability and latest features. [[1]](diffhunk://#diff-d4dc7b4e773430bc8af8329183e7fad305888baf3ca2c7bc5fa4091928eb5899L32-R48) [[2]](diffhunk://#diff-5b85b19552657ec533ea8b978312f05fbac1d801a5c1b774dfcbe0aaa974422dL45-R57)
* In `raw-capture-automerge.yml`, replaced manual pnpm enablement with the official `pnpm/action-setup@v6`, and enabled pnpm caching for faster installs.
* In `raw-inbox-import.yml`, set `package-manager-cache: false` for `setup-node` to control caching behavior.